### PR TITLE
MAR-463: Add SMS to Elixir OneSignal SDK

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -33,6 +33,7 @@ config :one_signal, OneSignal,
   app_id: "your app id",
   legacy_api_key: "your legacy api key",
   legacy_app_id: "your legacy app id",
+  sms_from: "your registered Twilio phone number in E.164 format",
   get_notification: &HTTPoison.get/2,
   post_notification: &HTTPoison.post/3,
   delete_notification: &HTTPoison.delete/2

--- a/lib/one_signal.ex
+++ b/lib/one_signal.ex
@@ -48,4 +48,8 @@ defmodule OneSignal do
   def fetch_app_id(:current) do
     Utils.config()[:app_id] || System.get_env("ONE_SIGNAL_APP_ID")
   end
+
+  def fetch_from_number() do
+    Utils.config()[:sms_from_number] || System.get_env("ONE_SIGNAL_SMS_FROM_NUMBER")
+  end
 end


### PR DESCRIPTION
From now on we will be using OpenSignal to send SMS messages, so we will leave Twilio aside. This change concludes support for that task.