### PR TITLE
Handle errors when response code is 200

### DIFF
--- a/lib/one_signal/api.ex
+++ b/lib/one_signal/api.ex
@@ -125,9 +125,9 @@ defmodule OneSignal.API do
 
   defp handle_response(%Response{body: body, status_code: code})
        when code in 200..299 do
-    with {:ok, result} <- Poison.decode(body) do
-      {:ok, result}
-    else
+    case Poison.decode(body) do
+      {:ok, %{"errors" => errors}} -> {:error, errors}
+      {:ok, result} -> {:ok, result}
       {:error, :invalid} -> {:error, {:invalid, "Could not parse invalid body"}}
       {:error, error} -> {:error, error}
       error -> {:error, {:unknown, "An unknown error has occured", error}}


### PR DESCRIPTION
Errors that were returned with a 200 status code (like "user not subscribed") are now properly handled as errors