### PR TITLE
MAR-1680: Misleading OneSignal error handling in Admin

### DIFF
--- a/lib/one_signal/api.ex
+++ b/lib/one_signal/api.ex
@@ -208,8 +208,8 @@ defmodule OneSignal.API do
       |> decompress_body(headers)
       |> json_library().decode!()
       |> case do
-        %{"errors" => api_error} ->
-          Error.from_onesignal_error(status, api_error)
+        %{"errors" => _api_error} = decoded_body ->
+          Error.from_onesignal_error(status, decoded_body)
 
         decoded_body ->
           decoded_body

--- a/lib/one_signal/error.ex
+++ b/lib/one_signal/error.ex
@@ -1,5 +1,5 @@
 defmodule OneSignal.Error do
-  defexception [:source, :code, :title, :meta]
+  defexception [:source, :code, :title, :meta, :id]
 
   @type error_source :: :internal | :network | :onesignal
 
@@ -17,7 +17,8 @@ defmodule OneSignal.Error do
           source: error_source,
           code: error_status | :network_error,
           title: String.t(),
-          meta: String.t() | nil
+          meta: String.t() | nil,
+          id: String.t() | nil
         }
 
   @doc false
@@ -45,7 +46,8 @@ defmodule OneSignal.Error do
     %__MODULE__{
       source: :onesignal,
       code: :unknown_error,
-      title: "#{inspect(error)}",
+      id: Map.get(error, "id"),
+      title: Map.get(error, "errors"),
       meta: error
     }
   end


### PR DESCRIPTION
Better handling of OneSignal errors by returning a Json response instead of a parsed text also included missing field `id`