### PR TITLE
MAR-1700: Adding support to delete subscription

### DIFF
--- a/lib/one_signal/converter.ex
+++ b/lib/one_signal/converter.ex
@@ -51,12 +51,22 @@ defmodule OneSignal.Converter do
     end
   end
 
-  defp convert_value(_, "/subscriptions" <> _) do
-    %{}
-  end
-
   defp convert_value(value, "/notifications" <> _) do
     value
+  end
+
+  defp convert_value(value, "/users/by/external_id/" <> rest) do
+    case String.split(rest, "/") do
+      [uuid, "subscriptions"] when is_binary(uuid) ->
+        convert_onesignal_object("onesignal.subscription", value)
+
+      _ ->
+        convert_onesignal_object("onesignal.user", value)
+    end
+  end
+
+  defp convert_value(value, "/subscriptions/" <> _rest) do
+    convert_onesignal_object("onesignal.subscription", value)
   end
 
   defp convert_value(value, "/users/by" <> _) do

--- a/lib/one_signal/subscription.ex
+++ b/lib/one_signal/subscription.ex
@@ -45,9 +45,9 @@ defmodule OneSignal.Subscription do
         }
 
   @type t :: %__MODULE__{
-    identity: OneSignal.Identity,
-    subscription: properties | nil
-  }
+          identity: OneSignal.Identity,
+          subscription: properties | nil
+        }
 
   defstruct [
     :identity,
@@ -123,6 +123,17 @@ defmodule OneSignal.Subscription do
     new_request(opts)
     |> put_endpoint("/subscriptions" <> "/#{subscription_id}")
     |> put_method(:delete)
+    |> make_request()
+  end
+
+  @spec transfer(OneSignal.id() | t, params, OneSignal.options()) ::
+          {:ok, t} | {:error, OneSignal.Error.t()}
+        when params: t
+  def transfer(id, params, opts \\ []) do
+    new_request(opts)
+    |> put_endpoint(plural_endpoint(id) <> "/owner")
+    |> put_method(:patch)
+    |> put_params(params)
     |> make_request()
   end
 end

--- a/lib/one_signal/subscription.ex
+++ b/lib/one_signal/subscription.ex
@@ -23,7 +23,7 @@ defmodule OneSignal.Subscription do
           | :Email
           | :SMS
 
-  @type t :: %__MODULE__{
+  @type properties :: %{
           id: OneSignal.id(),
           app_id: OneSignal.id(),
           type: type,
@@ -44,25 +44,15 @@ defmodule OneSignal.Subscription do
           carrier: String.t() | nil
         }
 
+  @type t :: %__MODULE__{
+    identity: OneSignal.Identity,
+    subscription: properties | nil
+  }
+
   defstruct [
-    :id,
-    :app_id,
-    :type,
-    :token,
-    :enabled,
-    :notification_types,
-    :session_time,
-    :session_count,
-    :sdk,
-    :device_model,
-    :device_os,
-    :rooted,
-    :test_type,
-    :app_version,
-    :net_type,
-    :carrier,
-    :web_auth,
-    :web_p256
+    :identity,
+    :subscription,
+    :properties
   ]
 
   @doc """
@@ -126,6 +116,13 @@ defmodule OneSignal.Subscription do
     |> put_endpoint("/users/by/#{retrieve_by}" <> "/#{get_id!(id)}" <> "/subscriptions")
     |> put_method(:post)
     |> put_params(params)
+    |> make_request()
+  end
+
+  def delete(subsctiption_id, opts \\ []) do
+    new_request(opts)
+    |> put_endpoint("/subscriptions" <> "/#{subsctiption_id}")
+    |> put_method(:delete)
     |> make_request()
   end
 end

--- a/lib/one_signal/subscription.ex
+++ b/lib/one_signal/subscription.ex
@@ -119,9 +119,9 @@ defmodule OneSignal.Subscription do
     |> make_request()
   end
 
-  def delete(subsctiption_id, opts \\ []) do
+  def delete(subscription_id, opts \\ []) do
     new_request(opts)
-    |> put_endpoint("/subscriptions" <> "/#{subsctiption_id}")
+    |> put_endpoint("/subscriptions" <> "/#{subscription_id}")
     |> put_method(:delete)
     |> make_request()
   end


### PR DESCRIPTION
This PR adds the functionality to delete subscriptions in OneSignal.

- New delete/2 method in OneSignal.Subscription
- Improvements in OneSignal.Converter
- Data structure refactoring